### PR TITLE
Handled case wherein iso8601 is null

### DIFF
--- a/src/timeAgo.js
+++ b/src/timeAgo.js
@@ -104,7 +104,7 @@ angular.module('yaru22.angular-timeago', [
     if (angular.isNumber(iso8601)) {
       return parseInt(iso8601, 10);
     }
-    var s = iso8601.trim();
+    var s = (iso8601 || '').trim();
     s = s.replace(/\.\d+/, ''); // remove milliseconds
     s = s.replace(/-/, '/').replace(/-/, '/');
     s = s.replace(/T/, ' ').replace(/Z/, ' UTC');


### PR DESCRIPTION
Prevented JS error when iso8601 variable = null
