### PR TITLE
Fix bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "test"
   ],
   "license": "MIT",
-  "main": "dist/angular-timeago.js",
+  "main": "src/timeAgo.js",
   "name": "angular-timeago",
   "repository": {
     "type": "git",


### PR DESCRIPTION
bower.json is malformed, the main is declared as a Hash with no key, it's actually a string or an array. In this case we only need a string.

```
$ bower install
bower angular-timeago#master       not-cached https://github.com/yaru22/angular-timeago.git#master
bower angular-timeago#master          resolve https://github.com/yaru22/angular-timeago.git#master
bower angular-timeago#master         checkout master
bower angular-timeago#master       EMALFORMED Failed to read /tmp/wmn/bower/angular-timeago-28391-Axniku/bower.json

Additional error details:
Unexpected token }
```
