### PR TITLE
Small fix to prevent 'Invalid Date' in directive caused by non intege…

### DIFF
--- a/src/timeAgo.js
+++ b/src/timeAgo.js
@@ -11,7 +11,7 @@ angular.module('yaru22.angular-timeago', [
 
       // Track the fromTime attribute
       attrs.$observe('fromTime', function (value) {
-        fromTime = timeAgo.parse(parseInt(value));
+        fromTime = timeAgo.parse(value);
       });
 
       // Track changes to time difference
@@ -203,7 +203,7 @@ angular.module('yaru22.angular-timeago', [
   };
 
   service.parse = function (iso8601) {
-    if (angular.isNumber(iso8601)) {
+    if (!angular.isNumber(iso8601)) {
       return parseInt(iso8601, 10);
     }
     if (iso8601 instanceof Date){

--- a/src/timeAgo.js
+++ b/src/timeAgo.js
@@ -11,7 +11,7 @@ angular.module('yaru22.angular-timeago', [
 
       // Track the fromTime attribute
       attrs.$observe('fromTime', function (value) {
-        fromTime = timeAgo.parse(value);
+        fromTime = timeAgo.parse(parseInt(value));
       });
 
       // Track changes to time difference


### PR DESCRIPTION
The directive was giving me NaN values when the from-time attribute had a timestamp in a string format.

example:
`<time-ago from-time='{{added}}'></time-ago> `

where `added` was `'1431858634555'` (string).

After further investigation it came out that timeAgo.parse(value) is returning 'Invalid Date' error in this case.

Wrapping `value` with `parseInt()` fixed the issue.
