### PR TITLE
Mangle friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ This configures `timeAgo` to use it's own filters (`about a minute ago`, `about 
 
 ###<a name="lang"/>Language support
 angular-timeago currently supports the following languages:  
-`en_US`, `de_DE`, `he_IL`, `pt_BR`, `it_IT`, `fr_FR`, `es_LA`, `nl_NL` and `ca_ES`.
+`en_US`, `de_DE`, `he_IL`, `pt_BR`, `it_IT`, `fr_FR`, `es_LA`, `nl_NL`, `ca_ES` and `sv_SE`.
 If you want more languages: feel free to contribute!
 The language is determined by the string in `document.documentElement.lang` which you can set in your HTML markup:
 ```

--- a/src/timeAgo.js
+++ b/src/timeAgo.js
@@ -21,7 +21,7 @@ angular.module('yaru22.angular-timeago', [
       });
     }
   };
-}]).factory('nowTime', function ($timeout) {
+}]).factory('nowTime', ['$timeout', function ($timeout) {
   var nowTime;
 
   function updateTime() {
@@ -33,7 +33,7 @@ angular.module('yaru22.angular-timeago', [
   return function () {
     return nowTime;
   };
-}).factory('timeAgo', ['$filter', function ($filter) {
+}]).factory('timeAgo', ['$filter', function ($filter) {
   var service = {};
 
   service.settings = {


### PR DESCRIPTION
nowTime uses implicit annotation for DI. The other services uses array annotation for DI. As is pointed out in the angular docs (https://docs.angularjs.org/guide/di), you can't mangle names with implicit annotation. Hence nowTime should use array notation too. :)

Also I forgot to add Swedish in the readme in an earlier pull request.