### PR TITLE
set filter as stateful filter

### DIFF
--- a/src/time-ago.filter.js
+++ b/src/time-ago.filter.js
@@ -1,9 +1,11 @@
 'use strict';
 
 angular.module('yaru22.angular-timeago').filter('timeAgo', function (nowTime, timeAgo) {
-  return function (value, format, timezone) {
+  function timeAgoFilter(value, format, timezone) {
     var fromTime = timeAgo.parse(value);
     var diff = nowTime() - fromTime;
     return timeAgo.inWords(diff, fromTime, format, timezone);
   };
+  timeAgoFilter.$stateful = true;
+  return timeAgoFilter;
 });


### PR DESCRIPTION
fix #54 
There was a breaking change between 1.3.0-RC.1 and 1.3.0-RC.2 : https://github.com/angular/angular.js/blob/master/CHANGELOG.md#breaking-changes-26
The filter function are not stateful anymore, that means that filter function do not get digest everytime if input doesn't change.
Since 1.3.0-RC.2, filter are now stateless. To make them the way they were before (stateful), a flag need to be add to the filter function.
Beware that there is a huge impact on performance as the filter will be process at every digest cycle !!!!