### PR TITLE
point main to dist/angular-timeago.js in bower.json & package.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "test"
   ],
   "license": "MIT",
-  "main": "src/timeAgo.js",
+  "main": "dist/angular-timeago.js",
   "name": "angular-timeago",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "protractor": "3.3.0",
     "serve-static": "1.10.2"
   },
-  "main": "src/timeAgo.js",
+  "main": "dist/angular-timeago.js",
   "scripts": {
     "test": "grunt test"
   }


### PR DESCRIPTION
This was previously pointing to a non-existent file named
src/timeAgo.js. Setting this field to dist/angular-timeago.js will
ensure that build systems are able to pick up this file.