### PR TITLE
Add compatibility to use with the "import" syntax.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./dist/angular-timeago');
+module.exports = 'yaru22.angular-timeago';

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "protractor": "4.0.11",
     "serve-static": "1.11.1"
   },
-  "main": "dist/angular-timeago.js",
+  "main": "index.js",
   "scripts": {
     "test": "grunt test"
   }


### PR DESCRIPTION
You can now use the module with this syntax:

import ngTimeAgo from 'angular-timeago';